### PR TITLE
Tiny grammar fix in English localization

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6,6 +6,6 @@
 		"message": "Provide a workaround to add search engines from Mycroft Project after Firefox 65."
 	},
 	"instruction": {
-		"message": "To add the search engine, click the \"⋯\" menu in the address bar, and select \"Add Search Engine\"."
+		"message": "To add the search engine, click the \"⋯\" menu in the address bar and select \"Add Search Engine\"."
 	}
 }


### PR DESCRIPTION
There is no comma before "and" in English.